### PR TITLE
Add material design themes for ubuntu

### DIFF
--- a/init
+++ b/init
@@ -231,6 +231,27 @@ installNode() {
   # or not. If successful show message, else show error.
 }
 
+# extra packages for design
+themePaper() {
+  breakline "Installing Paper theme and Icon pack"
+
+  sudo add-apt-repository -y ppa:snwh/pulp
+
+  sudo apt-get update
+
+  sudo apt-get install paper-gtk-theme paper-icon-theme
+}
+
+themeNumix() {
+  breakline "Installing Numix themne and Icon pack"
+
+  sudo apt-add-repository -y ppa:numix/ppa
+
+  sudo apt-get update
+
+  sudo apt-get install numix-icon-theme numix-icon-theme-circle
+}
+
 clearInstall() {
   breakline "Cleaning after installation"
 


### PR DESCRIPTION
Given that Material Design has spread in almost all OS's, why not add it
in Ubuntu also.

Read more about these packages on:
- [Numix theme installation](http://www.noobslab.com/2014/04/install-numix-icon-packs-in-ubuntulinux.html)
- [Paper theme installation](http://itsfoss.com/install-paper-theme-linux/)
